### PR TITLE
Arduino library

### DIFF
--- a/arduino/README.md
+++ b/arduino/README.md
@@ -1,0 +1,60 @@
+# Arduino code
+
+## ecamlib
+
+`ecamlib` is an Arduino library containing utility functions
+that can be used for different codes. Currently it contains
+a couple of functions to converts raw bytes to `int`, `float`
+and `long` types.
+
+#### Install
+
+To be able to use the library, you need to install it first.
+The Arduino IDE expects libraries to be located in a
+subfolder in the default sketch directory. For example
+`~/Documents/Arduino/libraries/` or `My Documents\Arduino\libraries\`.
+
+There are multiple ways to install the library:
+
+1. **ZIP**
+   The easiest solution is to zip the `ecamlib` folder
+   located in this repository and install it through the
+   Arduino IDE using the menu entry: `Sketch > Include Library > Add .ZIP Library ...`
+   This method is simple, but there are two things to keep in mind:
+   - If the code of the library changes, you need to do this
+     procedure again to have the latest changes.
+   - If you make the .zip in the repository, make sure to not
+     commit it when you make changes to other code.
+2. **Copy**
+   The second solution is to copy the ecamlib folder to the
+   Arduino library folder, a subdirectory called `libraries`
+   in your default sketch directory. With this method, you
+   need to redo this procedure whenever a change is made to
+   the library.
+3. **Symlink**
+   The symlink method is a little bit trickier, especially on Windows,
+   but it is the more robust solution. The idea, is to create
+   a symlink in the Arduino library that points to the `ecamlib`
+   folder in this repository.
+
+   **Windows:**
+   Open the command prompt and type:
+   ```
+   mklink /D "C:\path\to\Arduino\libraries" "C:\path\to\ecamlib"
+   ```
+   **Linux/MacOS:**
+   Open the terminal and type:
+   ```
+   sudo ln -s ~/path/to/ecamlib ~/path/to/Arduino/libraries/ecamlib
+   ```
+
+#### Usage
+When the library is installed in the Arduino IDE, you should be
+able to use it by selecting `Sketch > Include Library > ecamlib`
+You will probably need to scroll to the end of the list.
+
+It will add an include in the source file for you:
+
+```cpp
+#include <ecamlib.h>
+```

--- a/arduino/ecamlib/ecamlib.c
+++ b/arduino/ecamlib/ecamlib.c
@@ -13,3 +13,29 @@ float bytesToFloat(unsigned char b0, unsigned char b1, unsigned char b2, unsigne
 
     return number.f;
 }
+
+int bytesToInt(unsigned char b0, unsigned char b1) {
+    union {
+        int i;
+        unsigned char b[2];
+    } number;
+
+    number.b[0] = b0;
+    number.b[1] = b1;
+
+    return number.i;
+}
+
+long bytesToLong(unsigned char b0, unsigned char b1, unsigned char b2, unsigned char b3) {
+    union {
+        long l;
+        unsigned char b[4];
+    } number;
+
+    number.b[0] = b0;
+    number.b[1] = b1;
+    number.b[2] = b2;
+    number.b[3] = b3;
+
+    return number.l;
+}

--- a/arduino/ecamlib/ecamlib.c
+++ b/arduino/ecamlib/ecamlib.c
@@ -1,0 +1,15 @@
+#include "ecamlib.h"
+
+float bytesToFloat(unsigned char b0, unsigned char b1, unsigned char b2, unsigned char b3) {
+    union {
+        float f;
+        unsigned char b[4];
+    } number;
+
+    number.b[0] = b0;
+    number.b[1] = b1;
+    number.b[2] = b2;
+    number.b[3] = b3;
+
+    return number.f;
+}

--- a/arduino/ecamlib/ecamlib.h
+++ b/arduino/ecamlib/ecamlib.h
@@ -1,0 +1,31 @@
+#ifndef ecamlib_h
+#define ecamlib_h
+
+#if ARDUINO >= 100
+  #include "Arduino.h"
+#else
+  #include "WProgram.h"
+  #include "pins_arduino.h"
+  #include "WConstants.h"
+#endif
+
+/*
+    C++ performs name mangling, in order to be able to
+    call C functions from it we need to tell it to use 
+    the C convention for these functions.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    /*
+        bytesToFloat expects an array of four bytes and
+        converts them to a float value
+    */
+    float bytesToFloat(unsigned char b0, unsigned char b1, unsigned char b2, unsigned char b3);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/arduino/ecamlib/ecamlib.h
+++ b/arduino/ecamlib/ecamlib.h
@@ -24,6 +24,21 @@ extern "C" {
     */
     float bytesToFloat(unsigned char b0, unsigned char b1, unsigned char b2, unsigned char b3);
 
+    /*
+        bytesToInt expects an array of two bytes and
+        converts them to a int value. Because on the
+        Arduino Uno ints are 16-bits.
+    */
+    int bytesToInt(unsigned char b0, unsigned char b1);
+
+    /*
+        bytesToLong expects an array of four bytes and
+        converts them to a long value. Because on the
+        Arduino Uno longs are 32-bits.
+    */
+    long bytesToLong(unsigned char b0, unsigned char b1, unsigned char b2, unsigned char b3);
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR creates an Arduino library that can be used by placing it in a subdirectory of the default sketch directory named `libraries`. What I have done is to create a symlink in the Arduino library folder to the `ecamlib` folder in the repo to avoid copy-pasting when making a change, and it works great!

Currently this library contains only 1 function to convert from 4 bytes to a float, for example:

```cpp
#include <ecamlib.h>

void setup() {
  Serial.begin(9600);
}

void loop() {
  float f = bytesToFloat(174, 71, 33, 63);
  Serial.println(f);

  delay(1000);
}
```

prints the expected `0.63` floating-point number.

I will probably add a couple of other functions to perform byte conversions, useful for serial communication like I2C. And add some documentation about how to install and use the library.